### PR TITLE
Revert "fix ssh on flake-enabled system"

### DIFF
--- a/base.nix
+++ b/base.nix
@@ -105,9 +105,9 @@ with lib;
         nixbld:x:30000:nixbld1,nixbld10,nixbld2,nixbld3,nixbld4,nixbld5,nixbld6,nixbld7,nixbld8,nixbld9
       '';
       "ssh/ssh_host_rsa_key.pub".source = ./ssh/ssh_host_rsa_key.pub;
-      "ssh/ssh_host_rsa_key" = { source = pkgs.writeText "ssh_host_rsa" (builtins.readFile ./ssh/ssh_host_rsa_key); mode = "0600"; };
+      "ssh/ssh_host_rsa_key" = { mode = "0600"; source = ./ssh/ssh_host_rsa_key; };
       "ssh/ssh_host_ed25519_key.pub".source = ./ssh/ssh_host_ed25519_key.pub;
-      "ssh/ssh_host_ed25519_key" = { source = pkgs.writeText "ssh_host_ed25519" (builtins.readFile ./ssh/ssh_host_ed25519_key); mode = "0600";};
+      "ssh/ssh_host_ed25519_key" = { mode = "0600"; source = ./ssh/ssh_host_ed25519_key; };
     };
     boot.kernelParams = [ "systemConfig=${config.system.build.toplevel}" ];
     boot.kernelPackages = if pkgs.system == "armv7l-linux" then pkgs.linuxPackages_rpi1 else pkgs.linuxPackages;


### PR DESCRIPTION
This reverts commit ff6ea501206cc6e8bc6cd764df5feca442ec4fa2.

No longer needed since https://github.com/NixOS/nixpkgs/pull/136474