### PR TITLE
Update systemd options for recent nixpkgs

### DIFF
--- a/systemd-compat.nix
+++ b/systemd-compat.nix
@@ -9,6 +9,8 @@ with lib;
     };
     systemd.user = mkOption {
     };
+    systemd.tmpfiles = mkOption {
+    };
   };
   config = {
   };


### PR DESCRIPTION
## Description
This patch aims to:
- Add the new `systemd.tmpfiles` option on recent nixpkgs. This is to fix the error log when switching to nixpkgs 23.11:
```
error: The option `systemd.tmpfiles' does not exist. Definition values:
       - In `/nix/store/6h04ab83y72nm16hh9g3llgg0s296ynl-source/nixos/modules/system/activation/activation-script.nix':
           {
             rules = [
               "d /nix/var/nix/gcroots -"
               "L+ /nix/var/nix/gcroots/current-system - - - - /run/current-system"
               "D /var/empty 0555 root root -"
           ...
(use '--show-trace' to show detailed location information)
```