### PR TITLE
zynq: use u-boot wrapper for kernel and initrd and support for zc706

### DIFF
--- a/stage-1.nix
+++ b/stage-1.nix
@@ -190,6 +190,11 @@ let
   initialRamdisk = pkgs.makeInitrd {
     contents = [ { object = bootStage1; symlink = "/init"; } ];
   };
+  # Use for zynq_image
+  uRamdisk =  pkgs.makeInitrd {
+    makeUInitrd = true;
+    contents = [ { object = bootStage1; symlink = "/init"; } ];
+  };
 in
 {
   options = {
@@ -205,6 +210,7 @@ in
   config = {
     system.build.bootStage1 = bootStage1;
     system.build.initialRamdisk = initialRamdisk;
+    system.build.uRamdisk = uRamdisk;
     system.build.extraUtils = extraUtils;
     boot.initrd.availableKernelModules = [ ];
     boot.initrd.kernelModules = [ "tun" "loop" "squashfs" ] ++ (lib.optional config.not-os.nix "overlay");


### PR DESCRIPTION
## Description
This patch aims to:
1. Add support for u-boot wrapped kernel and initrd for zynq image
2. Use the `zc706` zynq variant

Reference:
- **initrd**: https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/18842473/Build+and+Modify+a+Rootfs
- **kernel**: https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/18842481/Build+kernel

Tested to boot on zynq-zc706 board.