### PR TITLE
zynq: add various boot fixes and cleanup

### DIFF
--- a/stage-2.nix
+++ b/stage-2.nix
@@ -21,6 +21,11 @@ with lib;
         type = types.str;
        };
     };
+    networking.hostName = mkOption {
+      default = "";
+      type = types.strMatching
+        "^$|^[[:alnum:]]([[:alnum:]_-]{0,61}[[:alnum:]])?$";
+    };
   };
   config = {
     system.build.bootStage2 = pkgs.substituteAll {

--- a/zynq_image.nix
+++ b/zynq_image.nix
@@ -13,54 +13,31 @@ in {
   imports = [ ./arm32-cross-fixes.nix ];
   boot.kernelPackages = customKernelPackages;
   nixpkgs.system = "armv7l-linux";
-  system.build.zynq_image = let
-    cmdline = "root=/dev/mmcblk0 console=ttyPS0,115200n8 systemConfig=${builtins.unsafeDiscardStringContext config.system.build.toplevel}";
-    qemuScript = ''
-      #!/bin/bash -v
-      export PATH=${x86pkgs.qemu}/bin:$PATH
-      set -x
-      base=$(dirname $0)
-
-      cp $base/root.squashfs /tmp/
-      chmod +w /tmp/root.squashfs
-      truncate -s 64m /tmp/root.squashfs
-
-      qemu-system-arm \
-        -M xilinx-zynq-a9 \
-        -serial /dev/null \
-        -serial stdio \
-        -display none \
-        -dtb $base/zynq-zc702.dtb \
-        -kernel $base/zImage \
-        -initrd $base/initrd \
-        -drive file=/tmp/root.squashfs,if=sd,format=raw \
-        -append "${cmdline}"
-    '';
-  in pkgs.runCommand "zynq_image" {
-    inherit qemuScript;
-    passAsFile = [ "qemuScript" ];
+  networking.hostName = "zynq";
+  system.build.zynq_image = pkgs.runCommand "zynq_image" {
     preferLocalBuild = true;
   } ''
     mkdir $out
     cd $out
-    cp -s ${config.system.build.squashfs} root.squashfs
     cp -s ${config.system.build.kernel}/*zImage .
     cp -s ${config.system.build.initialRamdisk}/initrd initrd
     cp -s ${config.system.build.kernel}/dtbs/zynq-zc702.dtb .
     ln -sv ${config.system.build.toplevel} toplevel
-    cp $qemuScriptPath qemu-script
-    chmod +x qemu-script
-    patchShebangs qemu-script
-    ls -ltrh
   '';
-  system.build.rpi_image_tar = pkgs.runCommand "dist.tar" {} ''
-    mkdir -p $out/nix-support
-    tar -cvf $out/dist.tar ${config.system.build.rpi_image}
-    echo "file binary-dist $out/dist.tar" >> $out/nix-support/hydra-build-products
-  '';
-  environment.systemPackages = [ pkgs.strace ];
-  environment.etc."service/getty/run".source = pkgs.writeShellScript "getty" ''
-    agetty ttyPS0 115200
-  '';
-  environment.etc."pam.d/other".text = "";
+  environment = {
+    systemPackages = with pkgs; [ strace inetutils ];
+    etc = {
+      "service/getty/run".source = pkgs.writeShellScript "getty" ''
+        hostname ${config.networking.hostName}
+        agetty ttyPS0 115200
+      '';
+      "pam.d/other".text = ''
+        auth     sufficient pam_permit.so
+        account  required pam_permit.so
+        password required pam_permit.so
+        session  optional pam_env.so
+      '';
+      "security/pam_env.conf".text = "";
+    };
+  };
 }


### PR DESCRIPTION
## Description
WIP

This patch aims to:
1. Fix missing hostname.
2. Fix unable to login.
3. Remove rpi build from zynq.
4. Proposal to remove the qemu script from the build, so users can freely modify this somewhere like a flake. This can make the system more flexible, while keeping only the minimal components accessible.
