### PR TITLE
zynq: various fixes and board support

### DIFF
--- a/base.nix
+++ b/base.nix
@@ -101,7 +101,10 @@ with lib;
       "ssl/certs/ca-certificates.crt".source = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
       "ssl/certs/ca-bundle.crt".source = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
       bashrc.text = "export PATH=/run/current-system/sw/bin";
-      profile.text = "export PATH=/run/current-system/sw/bin";
+      profile.text = ''
+        export PATH=/run/current-system/sw/bin
+        export EDITOR=nano
+      '';
       "resolv.conf".text = "nameserver 10.0.2.3";
       passwd.text = ''
         root:x:0:0:System administrator:/root:/run/current-system/sw/bin/bash

--- a/base.nix
+++ b/base.nix
@@ -91,11 +91,13 @@ with lib;
       "nix/nix.conf".source = pkgs.runCommand "nix.conf" {} ''
         extraPaths=$(for i in $(cat ${pkgs.writeReferencesToFile pkgs.runtimeShell}); do if test -d $i; then echo $i; fi; done)
         cat > $out << EOF
-        build-use-sandbox = true
+        auto-optimise-store = true
         build-users-group = nixbld
-        build-sandbox-paths = /bin/sh=${pkgs.runtimeShell} $(echo $extraPaths)
-        build-max-jobs = 1
-        build-cores = 4
+        cores = 0
+        extra-sandbox-paths = /bin/sh=${pkgs.runtimeShell} $(echo $extraPaths)
+        max-jobs = auto
+        sandbox = true
+        trusted-users = root
         EOF
       '';
       "ssl/certs/ca-certificates.crt".source = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";

--- a/base.nix
+++ b/base.nix
@@ -104,6 +104,7 @@ with lib;
       profile.text = ''
         export PATH=/run/current-system/sw/bin
         export EDITOR=nano
+        export NIX_PATH="nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixos:nixos-config=/etc/nixos/configuration.nix:/nix/var/nix/profiles/per-user/root/channels"
       '';
       "resolv.conf".text = "nameserver 10.0.2.3";
       passwd.text = ''

--- a/base.nix
+++ b/base.nix
@@ -98,6 +98,8 @@ with lib;
         build-cores = 4
         EOF
       '';
+      "ssl/certs/ca-certificates.crt".source = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+      "ssl/certs/ca-bundle.crt".source = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
       bashrc.text = "export PATH=/run/current-system/sw/bin";
       profile.text = "export PATH=/run/current-system/sw/bin";
       "resolv.conf".text = "nameserver 10.0.2.3";

--- a/base.nix
+++ b/base.nix
@@ -89,7 +89,7 @@ with lib;
     };
     environment.etc = {
       "nix/nix.conf".source = pkgs.runCommand "nix.conf" {} ''
-        extraPaths=$(for i in $(cat ${pkgs.writeReferencesToFile pkgs.runtimeShell}); do if test -d $i; then echo $i; fi; done)
+        extraPaths=$(for i in $(cat ${pkgs.writeClosure [ pkgs.bash ]}); do if test -d $i; then echo $i; fi; done)
         cat > $out << EOF
         auto-optimise-store = true
         build-users-group = nixbld

--- a/base.nix
+++ b/base.nix
@@ -27,6 +27,11 @@ with lib;
       description = "enable rngd";
       default = false;
     };
+    not-os.sd = mkOption {
+      type = types.bool;
+      default = false;
+      description = "enable sd image support";
+    };
     not-os.simpleStaticIp = mkOption {
       type = types.bool;
       default = false;

--- a/runit.nix
+++ b/runit.nix
@@ -65,7 +65,6 @@ in
       '';
       "service/nix/run".source = pkgs.writeScript "nix" ''
         #!${pkgs.runtimeShell}
-        nix-store --load-db < /nix/store/nix-path-registration
         nix-daemon
       '';
     }

--- a/stage-1.nix
+++ b/stage-1.nix
@@ -164,7 +164,9 @@ let
     mkdir -p /mnt/nix/store/
 
 
-    ${if config.not-os.nix then ''
+    ${if config.not-os.sd && config.not-os.nix then ''
+    mount $root /mnt
+    '' else if config.not-os.nix then ''
     # make the store writeable
     mkdir -p /mnt/nix/.ro-store /mnt/nix/.overlay-store /mnt/nix/store
     mount $root /mnt/nix/.ro-store -t squashfs

--- a/stage-1.nix
+++ b/stage-1.nix
@@ -190,6 +190,11 @@ let
   initialRamdisk = pkgs.makeInitrd {
     contents = [ { object = bootStage1; symlink = "/init"; } ];
   };
+  # Use for zynq_image
+  uRamdisk =  pkgs.makeInitrd {
+    makeUInitrd = true;
+    contents = [ { object = bootStage1; symlink = "/init"; } ];
+  };
 in
 {
   options = {
@@ -205,6 +210,7 @@ in
   config = {
     system.build.bootStage1 = bootStage1;
     system.build.initialRamdisk = initialRamdisk;
+    system.build.uRamdisk = uRamdisk;
     system.build.extraUtils = extraUtils;
     boot.initrd.availableKernelModules = [ ];
     boot.initrd.kernelModules = [ "tun" "loop" "squashfs" ] ++ (lib.optional config.not-os.nix "overlay");

--- a/stage-1.nix
+++ b/stage-1.nix
@@ -117,11 +117,6 @@ let
     plymouth --show-splash
     ''}
 
-
-    for x in ${lib.concatStringsSep " " config.boot.initrd.kernelModules}; do
-      modprobe $x
-    done
-
     root=/dev/vda
     realroot=tmpfs
     for o in $(cat /proc/cmdline); do

--- a/stage-1.nix
+++ b/stage-1.nix
@@ -158,22 +158,41 @@ let
     chmod 755 /mnt/
     mkdir -p /mnt/nix/store/
 
-
     ${if config.not-os.sd && config.not-os.nix then ''
-    mount $root /mnt
-    '' else if config.not-os.nix then ''
-    # make the store writeable
-    mkdir -p /mnt/nix/.ro-store /mnt/nix/.overlay-store /mnt/nix/store
-    mount $root /mnt/nix/.ro-store -t squashfs
-    if [ $realroot = $1 ]; then
-      mount tmpfs -t tmpfs /mnt/nix/.overlay-store -o size=1G
-    fi
-    mkdir -pv /mnt/nix/.overlay-store/work /mnt/nix/.overlay-store/rw
-    modprobe overlay
-    mount -t overlay overlay -o lowerdir=/mnt/nix/.ro-store,upperdir=/mnt/nix/.overlay-store/rw,workdir=/mnt/nix/.overlay-store/work /mnt/nix/store
-    '' else ''
-    # readonly store
-    mount $root /mnt/nix/store/ -t squashfs
+      mkdir -p /boot
+      mount -t vfat -o ro /dev/mmcblk0p1 /boot
+      USE_READONLY=1
+      if [ -e /boot/fs_mode_rw ]; then
+        echo "Found fs_mode_rw file, enabling read-write mode"
+        USE_READONLY=0
+      fi
+      if [ "$USE_READONLY" = "1" ]; then
+        mkdir -p /mnt.ro /mnt.overlay
+        mount -o ro $root /mnt.ro
+        mount -t tmpfs -o size=1G tmpfs /mnt.overlay
+        mkdir -p /mnt.overlay/upper /mnt.overlay/work
+        mount -t overlay overlay -o lowerdir=/mnt.ro,upperdir=/mnt.overlay/upper,workdir=/mnt.overlay/work /mnt
+        mkdir -p /mnt/boot
+      else
+        mount $root /mnt
+        mkdir -p /mnt/boot
+      fi
+      mount --move /boot /mnt/boot
+    ''
+    else if config.not-os.nix then ''
+      # make the store writeable
+      mkdir -p /mnt/nix/.ro-store /mnt/nix/.overlay-store /mnt/nix/store
+      mount $root /mnt/nix/.ro-store -t squashfs
+      if [ $realroot = $1 ]; then
+        mount tmpfs -t tmpfs /mnt/nix/.overlay-store -o size=1G
+      fi
+      mkdir -pv /mnt/nix/.overlay-store/work /mnt/nix/.overlay-store/rw
+      modprobe overlay
+      mount -t overlay overlay -o lowerdir=/mnt/nix/.ro-store,upperdir=/mnt/nix/.overlay-store/rw,workdir=/mnt/nix/.overlay-store/work /mnt/nix/store
+    ''
+    else ''
+      # readonly store
+      mount $root /mnt/nix/store/ -t squashfs
     ''}
 
     ${lib.optionalString enablePlymouth ''

--- a/stage-1.nix
+++ b/stage-1.nix
@@ -169,7 +169,7 @@ let
       if [ "$USE_READONLY" = "1" ]; then
         mkdir -p /mnt.ro /mnt.overlay
         mount -o ro $root /mnt.ro
-        mount -t tmpfs -o size=1G tmpfs /mnt.overlay
+        mount -t tmpfs -o size=256M tmpfs /mnt.overlay
         mkdir -p /mnt.overlay/upper /mnt.overlay/work
         mount -t overlay overlay -o lowerdir=/mnt.ro,upperdir=/mnt.overlay/upper,workdir=/mnt.overlay/work /mnt
         mkdir -p /mnt/boot

--- a/stage-2-init.sh
+++ b/stage-2-init.sh
@@ -19,4 +19,7 @@ mount -t tmpfs tmpfs /dev/shm
 
 $systemConfig/activate
 
+# Run any user-specified commands.
+@runtimeShell@ @postBootCommands@
+
 exec runit

--- a/stage-2.nix
+++ b/stage-2.nix
@@ -21,6 +21,11 @@ with lib;
         type = types.str;
        };
     };
+    networking.hostName = mkOption {
+      default = "";
+      type = types.strMatching
+        "^$|^[[:alnum:]]([[:alnum:]_-]{0,61}[[:alnum:]])?$";
+    };
   };
   config = {
     system.build.bootStage2 = pkgs.substituteAll {

--- a/stage-2.nix
+++ b/stage-2.nix
@@ -20,6 +20,14 @@ with lib;
         example = "256m";
         type = types.str;
        };
+      postBootCommands = mkOption {
+        default = "";
+        example = "rm -f /var/log/messages";
+        type = types.lines;
+        description = lib.mdDoc ''
+          Shell commands to be executed just before runit is started.
+        '';
+      };
     };
     networking.hostName = mkOption {
       default = "";
@@ -33,6 +41,9 @@ with lib;
       isExecutable = true;
       path = config.system.path;
       inherit (pkgs) runtimeShell;
+      postBootCommands = pkgs.writeText "local-cmds" ''
+        ${config.boot.postBootCommands}
+      '';
     };
   };
 }

--- a/zynq_image.nix
+++ b/zynq_image.nix
@@ -46,7 +46,7 @@ in {
     ln -sv ${config.system.build.toplevel} toplevel
   '';
   environment = {
-    systemPackages = with pkgs; [ strace inetutils ];
+    systemPackages = with pkgs; [ inetutils wget ];
     etc = {
       "service/getty/run".source = pkgs.writeShellScript "getty" ''
         hostname ${config.networking.hostName}

--- a/zynq_image.nix
+++ b/zynq_image.nix
@@ -20,6 +20,12 @@ let
   customKernel = (crosspkgs.linux.override {
     extraConfig = ''
       OVERLAY_FS y
+      MEDIA_SUPPORT n
+      FB n
+      DRM n
+      SOUND n
+      SQUASHFS n
+      BACKLIGHT_CLASS_DEVICE n
     '';
   }).overrideAttrs (oa: {
     postInstall = ''

--- a/zynq_image.nix
+++ b/zynq_image.nix
@@ -32,6 +32,7 @@ in {
   boot.kernelPackages = customKernelPackages;
   nixpkgs.system = "armv7l-linux";
   networking.hostName = "zynq";
+  not-os.sd = true;
   system.build.zynq_image = pkgs.runCommand "zynq_image" {
     preferLocalBuild = true;
   } ''

--- a/zynq_image.nix
+++ b/zynq_image.nix
@@ -2,22 +2,7 @@
 
 with lib;
 let
-  crosspkgs = import pkgs.path {
-    system = "x86_64-linux";
-    crossSystem = {
-      system = "armv7l-linux";
-      linux-kernel = {
-        name = "zynq";
-        baseConfig = "multi_v7_defconfig";
-        target = "uImage";
-        installTarget = "uImage";
-        autoModules = false;
-        DTB = true;
-        makeFlags = [ "LOADADDR=0x8000" ];
-      };
-    };
-  };
-  customKernel = (crosspkgs.linux.override {
+  customKernel = (pkgs.linux_6_6.override {
     extraConfig = ''
       OVERLAY_FS y
       MEDIA_SUPPORT n
@@ -35,11 +20,13 @@ let
     '';
   }).overrideAttrs (oa: {
     postInstall = ''
-      cp arch/arm/boot/uImage $out
+      if [ -e arch/arm/boot/uImage ]; then
+        cp arch/arm/boot/uImage $out
+      fi
       ${oa.postInstall}
     '';
   });
-  customKernelPackages = crosspkgs.linuxPackagesFor customKernel;
+  customKernelPackages = pkgs.linuxPackagesFor customKernel;
 in {
   imports = [ ./arm32-cross-fixes.nix ];
   boot.kernelPackages = customKernelPackages;

--- a/zynq_image.nix
+++ b/zynq_image.nix
@@ -52,7 +52,7 @@ in {
     ln -sv ${config.system.build.toplevel} toplevel
   '';
   environment = {
-    systemPackages = with pkgs; [ inetutils wget ];
+    systemPackages = with pkgs; [ inetutils wget nano ];
     etc = {
       "service/getty/run".source = pkgs.writeShellScript "getty" ''
         hostname ${config.networking.hostName}

--- a/zynq_image.nix
+++ b/zynq_image.nix
@@ -45,7 +45,7 @@ in {
     ln -sv ${config.system.build.toplevel} toplevel
   '';
   environment = {
-    systemPackages = with pkgs; [ inetutils wget nano ];
+    systemPackages = with pkgs; [ inetutils wget gnugrep nano vim ];
     etc = {
       "service/getty/run".source = pkgs.writeShellScript "getty" ''
         hostname ${config.networking.hostName}

--- a/zynq_image.nix
+++ b/zynq_image.nix
@@ -33,6 +33,7 @@ in {
   nixpkgs.system = "armv7l-linux";
   networking.hostName = "zynq";
   not-os.sd = true;
+  not-os.simpleStaticIp = true;
   system.build.zynq_image = pkgs.runCommand "zynq_image" {
     preferLocalBuild = true;
   } ''

--- a/zynq_image.nix
+++ b/zynq_image.nix
@@ -26,6 +26,12 @@ let
       SOUND n
       SQUASHFS n
       BACKLIGHT_CLASS_DEVICE n
+      FPGA y
+      FPGA_BRIDGE y
+      FPGA_REGION y
+      OF_FPGA_REGION y
+      FPGA_MGR_ZYNQ_FPGA y
+      OF_OVERLAY y
     '';
   }).overrideAttrs (oa: {
     postInstall = ''

--- a/zynq_image.nix
+++ b/zynq_image.nix
@@ -50,7 +50,7 @@ in {
     etc = {
       "service/getty/run".source = pkgs.writeShellScript "getty" ''
         hostname ${config.networking.hostName}
-        agetty ttyPS0 115200
+        exec setsid agetty ttyPS0 115200
       '';
       "pam.d/other".text = ''
         auth     sufficient pam_permit.so

--- a/zynq_image.nix
+++ b/zynq_image.nix
@@ -1,66 +1,61 @@
 { config, pkgs, ... }:
 
 let
-  # dont use overlays for the qemu, it causes a lot of wasted time on recompiles
-  x86pkgs = import pkgs.path { system = "x86_64-linux"; };
-  customKernel = pkgs.linux.override {
+  crosspkgs = import pkgs.path {
+    system = "x86_64-linux";
+    crossSystem = {
+      system = "armv7l-linux";
+      linux-kernel = {
+        name = "zynq";
+        baseConfig = "multi_v7_defconfig";
+        target = "uImage";
+        installTarget = "uImage";
+        autoModules = false;
+        DTB = true;
+        makeFlags = [ "LOADADDR=0x8000" ];
+      };
+    };
+  };
+  customKernel = (crosspkgs.linux.override {
     extraConfig = ''
       OVERLAY_FS y
     '';
-  };
-  customKernelPackages = pkgs.linuxPackagesFor customKernel;
+  }).overrideAttrs (oa: {
+    postInstall = ''
+      cp arch/arm/boot/uImage $out
+      ${oa.postInstall}
+    '';
+  });
+  customKernelPackages = crosspkgs.linuxPackagesFor customKernel;
 in {
   imports = [ ./arm32-cross-fixes.nix ];
   boot.kernelPackages = customKernelPackages;
   nixpkgs.system = "armv7l-linux";
-  system.build.zynq_image = let
-    cmdline = "root=/dev/mmcblk0 console=ttyPS0,115200n8 systemConfig=${builtins.unsafeDiscardStringContext config.system.build.toplevel}";
-    qemuScript = ''
-      #!/bin/bash -v
-      export PATH=${x86pkgs.qemu}/bin:$PATH
-      set -x
-      base=$(dirname $0)
-
-      cp $base/root.squashfs /tmp/
-      chmod +w /tmp/root.squashfs
-      truncate -s 64m /tmp/root.squashfs
-
-      qemu-system-arm \
-        -M xilinx-zynq-a9 \
-        -serial /dev/null \
-        -serial stdio \
-        -display none \
-        -dtb $base/zynq-zc702.dtb \
-        -kernel $base/zImage \
-        -initrd $base/initrd \
-        -drive file=/tmp/root.squashfs,if=sd,format=raw \
-        -append "${cmdline}"
-    '';
-  in pkgs.runCommand "zynq_image" {
-    inherit qemuScript;
-    passAsFile = [ "qemuScript" ];
+  networking.hostName = "zynq";
+  system.build.zynq_image = pkgs.runCommand "zynq_image" {
     preferLocalBuild = true;
   } ''
     mkdir $out
     cd $out
-    cp -s ${config.system.build.squashfs} root.squashfs
-    cp -s ${config.system.build.kernel}/*zImage .
-    cp -s ${config.system.build.initialRamdisk}/initrd initrd
-    cp -s ${config.system.build.kernel}/dtbs/zynq-zc702.dtb .
+    cp -s ${config.system.build.kernel}/uImage .
+    cp -s ${config.system.build.uRamdisk}/initrd uRamdisk.image.gz
+    cp -s ${config.system.build.kernel}/dtbs/zynq-zc706.dtb devicetree.dtb
     ln -sv ${config.system.build.toplevel} toplevel
-    cp $qemuScriptPath qemu-script
-    chmod +x qemu-script
-    patchShebangs qemu-script
-    ls -ltrh
   '';
-  system.build.rpi_image_tar = pkgs.runCommand "dist.tar" {} ''
-    mkdir -p $out/nix-support
-    tar -cvf $out/dist.tar ${config.system.build.rpi_image}
-    echo "file binary-dist $out/dist.tar" >> $out/nix-support/hydra-build-products
-  '';
-  environment.systemPackages = [ pkgs.strace ];
-  environment.etc."service/getty/run".source = pkgs.writeShellScript "getty" ''
-    agetty ttyPS0 115200
-  '';
-  environment.etc."pam.d/other".text = "";
+  environment = {
+    systemPackages = with pkgs; [ strace inetutils ];
+    etc = {
+      "service/getty/run".source = pkgs.writeShellScript "getty" ''
+        hostname ${config.networking.hostName}
+        agetty ttyPS0 115200
+      '';
+      "pam.d/other".text = ''
+        auth     sufficient pam_permit.so
+        account  required pam_permit.so
+        password required pam_permit.so
+        session  optional pam_env.so
+      '';
+      "security/pam_env.conf".text = "";
+    };
+  };
 }

--- a/zynq_image.nix
+++ b/zynq_image.nix
@@ -5,6 +5,8 @@ let
   customKernel = (pkgs.linux_6_6.override {
     extraConfig = ''
       OVERLAY_FS y
+      NLS_CODEPAGE_437 y
+      NLS_ISO8859_1 y
       MEDIA_SUPPORT n
       FB n
       DRM n


### PR DESCRIPTION
## Description
This PR aims to unify all zynq image related patches.

List of patches from this PR:
1. Add support for u-boot wrapped [kernel](https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/18842481/Build+kernel) and [initrd](https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/18842473/Build+and+Modify+a+Rootfs) (Xilinx recommended).
2. Use the `zc706` zynq variant.
3. Add hostname.
4. Enable login.
5. Remove the qemu script from the build, so users can freely modify this somewhere like a flake. This can make the system more flexible, while keeping only the minimal components accessible.
6. Add boot from sd image support.

Combine the changes from: #26 and #27.