### PR TITLE
Configure shutdown instructions in runit stage 3

### DIFF
--- a/runit.nix
+++ b/runit.nix
@@ -57,6 +57,23 @@ in
       '';
       "runit/3".source = pkgs.writeScript "3" ''
         #!${pkgs.runtimeShell}
+        echo Waiting for services to stop...
+        sv force-stop /etc/service/*
+        sv exit /etc/service/*
+
+        echo Sending TERM signal to processes...
+        pkill --inverse -s0,1 -TERM
+        sleep 1
+        echo Sending KILL signal to processes...
+        pkill --inverse -s0,1 -KILL
+
+        echo Unmounting filesystems, disabling swap...
+        swapoff -a
+        umount -r -a -t nosysfs,noproc,nodevtmpfs,notmpfs
+        echo Remounting rootfs read-only...
+        mount -o remount,ro /
+
+        sync
         echo and down we go
       '';
       "service/sshd/run".source = pkgs.writeScript "sshd_run" ''


### PR DESCRIPTION
### Description

Proposal for additional instructions for clean shutdown during `poweroff/reboot`

As referred from [void linux](https://github.com/void-linux/void-runit/blob/20220329/3), another linux distro that uses runit as its init system.

Sample reboot log:
```
-bash-5.2# reboot
-bash-5.2# - runit: leave stage: /etc/runit/2
- runit: enter stage: /etc/runit/3
Waiting for services to stop...
ok: down: /etc/service/sshd: 0s, normally up, want up
ok: down: /etc/service/getty: 1s, normally up
ok: down: /etc/service/nix: 1s, normally up
Sending TERM signal to processes...
Sending KILL signal to processes...
Unmounting filesystems, disabling swap...
[   28.133778] EXT4-fs (mmcblk0p2): re-mounted. Quota mode: disabled.
Remounting rootfs read-only...
[   28.159920] EXT4-fs (mmcblk0p2): re-mounted. Quota mode: disabled.
and down we go
- runit: leave stage: /etc/runit/3
- runit: sending KILL signal to all processes...
- runit: system reboot.
[   28.208198] reboot: Restarting system
```
```
<<< NotOS Stage 1 >>>

'/bin/sh' -> '/nix/store/nynxwgjp72dl773qmgs6v7xvm79bvvbc-extra-utils-armv7l-unknown-linux-gnueabihf/bin/ash'
[    1.703390] EXT4-fs (mmcblk0p2): mounted filesystem with ordered data mode. Quota mode: disabled.
```