### PR TITLE
Update to nixpkgs 26.05

### DIFF
--- a/arm32-cross-fixes.nix
+++ b/arm32-cross-fixes.nix
@@ -11,7 +11,13 @@
       systemd = super.systemd.override { withEfi = false; };
       util-linux = super.util-linux.override { systemdSupport = false; };
       procps = super.procps.override { withSystemd = false; };
-      nix = super.nix.override { enableDocumentation = false; };
+      # Building nix's manual pulls in mdbook (Rust). We don't need the manual,
+      # so swap it for an empty stub to keep mdbook out of the build.
+      nix = super.nix.override {
+        nix-manual = self.runCommand "nix-manual" { outputs = [ "out" "man" ]; } ''
+          mkdir -p "$out" "$man"
+        '';
+      };
     })
   ];
 }

--- a/base.nix
+++ b/base.nix
@@ -70,24 +70,11 @@ with lib;
     nixpkgs.config = {
       packageOverrides = self: {
         dhcpcd = self.dhcpcd.override { udev = null; };
-        linux_rpixxx = self.linux_rpi.override {
-          extraConfig = ''
-            DEBUG_LL y
-            EARLY_PRINTK y
-            DEBUG_BCM2708_UART0 y
-            ARM_APPENDED_DTB n
-            ARM_ATAG_DTB_COMPAT n
-            ARCH_BCM2709 y
-            BCM2708_GPIO y
-            BCM2708_NOL2CACHE y
-            BCM2708_SPIDEV y
-          '';
-        };
       };
     };
     environment.etc = {
       "nix/nix.conf".source = pkgs.runCommand "nix.conf" {} ''
-        extraPaths=$(for i in $(cat ${pkgs.writeReferencesToFile pkgs.runtimeShell}); do if test -d $i; then echo $i; fi; done)
+        extraPaths=$(for i in $(cat ${pkgs.writeClosure [ pkgs.bash ]}); do if test -d $i; then echo $i; fi; done)
         cat > $out << EOF
         build-use-sandbox = true
         build-users-group = nixbld

--- a/base.nix
+++ b/base.nix
@@ -69,7 +69,6 @@ with lib;
     environment.systemPackages = lib.optional config.not-os.nix pkgs.nix;
     nixpkgs.config = {
       packageOverrides = self: {
-        utillinux = self.utillinux.override { systemd = null; systemdSupport = false; };
         dhcpcd = self.dhcpcd.override { udev = null; };
         linux_rpixxx = self.linux_rpi.override {
           extraConfig = ''

--- a/configuration.nix
+++ b/configuration.nix
@@ -3,7 +3,7 @@
 {
   imports = [ ./qemu.nix ];
   not-os.nix = true;
-  environment.systemPackages = [ pkgs.utillinux ];
+  environment.systemPackages = [ pkgs.util-linux ];
   environment.etc = {
     "ssh/authorized_keys.d/root" = {
       text = ''

--- a/flake.lock
+++ b/flake.lock
@@ -18,16 +18,18 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1697730408,
-        "narHash": "sha256-Ww//zzukdTrwTrCUkaJA/NsaLEfUfQpWZXBdXBYfhak=",
+        "lastModified": 1780902259,
+        "narHash": "sha256-q8yYEC5f1mFlQO9RGna4LTc9QrcvWunX6FYp83munkQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ff0a5a776b56e0ca32d47a4a47695452ec7f7d80",
+        "rev": "bd0ff2d3eac24699c3664d5966b9ef36f388e2ca",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixos-26.05",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,6 @@
 {
   inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     firmware = {
       url = "github:raspberrypi/firmware";
       flake = false;

--- a/rpi_image.nix
+++ b/rpi_image.nix
@@ -47,7 +47,7 @@
   nixpkgs.overlays = [
     (self: super: {
       openssh = super.openssh.override { withFIDO = false; withKerberos = false; };
-      util-linux = super.util-linux.override { pamSupport=false; capabilitiesSupport=false; ncursesSupport=false; systemdSupport=false; nlsSupport=false; translateManpages=false; };
+      util-linux = super.util-linux.override { pamSupport=false; withLastlog=false; capabilitiesSupport=false; ncursesSupport=false; systemdSupport=false; nlsSupport=false; translateManpages=false; };
       utillinuxCurses = self.util-linux;
       utillinuxMinimal = self.util-linux;
     })

--- a/stage-2.nix
+++ b/stage-2.nix
@@ -23,11 +23,15 @@ with lib;
     };
   };
   config = {
-    system.build.bootStage2 = pkgs.substituteAll {
+    system.build.bootStage2 = pkgs.replaceVarsWith {
       src = ./stage-2-init.sh;
       isExecutable = true;
-      path = config.system.path;
-      inherit (pkgs) runtimeShell;
+      replacements = {
+        path = config.system.path;
+        inherit (pkgs) runtimeShell;
+        # null keeps @systemConfig@ in the file; toplevel fills it in later.
+        systemConfig = null;
+      };
     };
   };
 }

--- a/system-path.nix
+++ b/system-path.nix
@@ -6,7 +6,7 @@
 with lib;
 
 let
-  requiredPackages = with pkgs; [ utillinux coreutils iproute iputils procps bashInteractive runit ];
+  requiredPackages = with pkgs; [ util-linux coreutils iproute2 iputils procps bashInteractive runit ];
 in
 {
   options = {


### PR DESCRIPTION
Bumps the flake to nixpkgs `26.05` and fixes the breakage from the jump (package renames, removed override args, `substituteAll` → `replaceVarsWith`). Also drops some dead config in `base.nix`.