### PR TITLE
dhcpcd: use withUdev flag, drop dead override

### DIFF
--- a/base.nix
+++ b/base.nix
@@ -69,7 +69,7 @@ with lib;
     environment.systemPackages = lib.optional config.not-os.nix pkgs.nix;
     nixpkgs.config = {
       packageOverrides = self: {
-        dhcpcd = self.dhcpcd.override { udev = null; };
+        dhcpcd = self.dhcpcd.override { withUdev = false; };
       };
     };
     environment.etc = {

--- a/stage-1.nix
+++ b/stage-1.nix
@@ -21,7 +21,6 @@ let
     };
     #patches2 = [ ./fix2.patch ./udev3.patch ];
   });
-  dhcpcd = pkgs.dhcpcd.override { udev = null; };
   extraUtils = pkgs.runCommandCC "extra-utils"
   {
     nativeBuildInputs = [ pkgs.nukeReferences ];


### PR DESCRIPTION
`withUdev=false` is now the proper way to build `dhcpcd` without `udev`; `udev=null` was the old hack. Also remove an unused `dhcpcd` binding in `stage-1`.