### PR TITLE
base: modernize `nix.conf`, add `cacert` and `NIX_PATH`

### DIFF
--- a/base.nix
+++ b/base.nix
@@ -76,15 +76,22 @@ with lib;
       "nix/nix.conf".source = pkgs.runCommand "nix.conf" {} ''
         extraPaths=$(for i in $(cat ${pkgs.writeClosure [ pkgs.bash ]}); do if test -d $i; then echo $i; fi; done)
         cat > $out << EOF
-        build-use-sandbox = true
+        auto-optimise-store = true
         build-users-group = nixbld
-        build-sandbox-paths = /bin/sh=${pkgs.runtimeShell} $(echo $extraPaths)
-        build-max-jobs = 1
-        build-cores = 4
+        cores = 0
+        extra-sandbox-paths = /bin/sh=${pkgs.runtimeShell} $(echo $extraPaths)
+        max-jobs = auto
+        sandbox = true
+        trusted-users = root
         EOF
       '';
+      "ssl/certs/ca-certificates.crt".source = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+      "ssl/certs/ca-bundle.crt".source = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
       bashrc.text = "export PATH=/run/current-system/sw/bin";
-      profile.text = "export PATH=/run/current-system/sw/bin";
+      profile.text = ''
+        export PATH=/run/current-system/sw/bin
+        export NIX_PATH="nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixos:nixos-config=/etc/nixos/configuration.nix:/nix/var/nix/profiles/per-user/root/channels"
+      '';
       "resolv.conf".text = "nameserver 10.0.2.3";
       passwd.text = ''
         root:x:0:0:System administrator:/root:/run/current-system/sw/bin/bash


### PR DESCRIPTION
- `nix.conf`: use current option names (sandbox, max-jobs, cores, extra-sandbox-paths), enable `auto-optimise-store` and `trusted-users`
- add `ca-certificates` so TLS works
- set `NIX_PATH` in the login profile