### PR TITLE
add `boot.postBootCommands` hook

### DIFF
--- a/stage-2-init.sh
+++ b/stage-2-init.sh
@@ -19,4 +19,7 @@ mount -t tmpfs tmpfs /dev/shm
 
 $systemConfig/activate
 
+# Run any user-specified commands.
+@postBootCommands@
+
 exec runit

--- a/stage-2.nix
+++ b/stage-2.nix
@@ -20,6 +20,14 @@ with lib;
         example = "256m";
         type = types.str;
        };
+      postBootCommands = mkOption {
+        default = "";
+        example = "rm -f /var/log/messages";
+        type = types.lines;
+        description = ''
+          Shell commands to be executed just before runit is started.
+        '';
+      };
     };
   };
   config = {
@@ -31,6 +39,9 @@ with lib;
         inherit (pkgs) runtimeShell;
         # null keeps @systemConfig@ in the file; toplevel fills it in later.
         systemConfig = null;
+        postBootCommands = pkgs.writeShellScript "local-cmds" ''
+          ${config.boot.postBootCommands}
+        '';
       };
     };
   };


### PR DESCRIPTION
Run user-specified shell commands just before `runit` starts. Useful for first-boot maintenance tasks.