### PR TITLE
recreate `/var/tmp` and `/var/empty` in activation

### DIFF
--- a/base.nix
+++ b/base.nix
@@ -148,6 +148,23 @@ with lib;
       # dummy to make setup-etc happy
     '';
     system.activationScripts.etc = stringAfter [ "users" "groups" ] config.system.build.etcActivationCommands;
+    # nixpkgs moved /var setup into systemd.tmpfiles, which not-os ignores,
+    # so recreate the directories here. See nixpkgs commit 59e3726755.
+    system.activationScripts.var = lib.mkForce ''
+      # Various log/runtime directories.
+
+      mkdir -p /var/tmp
+      chmod 1777 /var/tmp
+
+      # Empty, immutable home directory of many system accounts.
+      mkdir -p /var/empty
+      # Make sure it's really empty
+      ${pkgs.e2fsprogs}/bin/chattr -f -i /var/empty || true
+      find /var/empty -mindepth 1 -delete
+      chmod 0555 /var/empty
+      chown root:root /var/empty
+      ${pkgs.e2fsprogs}/bin/chattr -f +i /var/empty || true
+    '';
 
     # nix-build -A system.build.toplevel && du -h $(nix-store -qR result) --max=0 -BM|sort -n
     system.build.toplevel = pkgs.runCommand "not-os" {


### PR DESCRIPTION
[nixpkgs moved these into systemd.tmpfiles](https://github.com/NixOS/nixpkgs/commit/59e37267556eb917146ca3110ab7c96905b9ffbd), which not-os ignores, so they were no longer being created. Restore the manual setup.