### PR TITLE
arm32-cross-fixes: drop Rust from `ubootTools`

### DIFF
--- a/arm32-cross-fixes.nix
+++ b/arm32-cross-fixes.nix
@@ -18,6 +18,8 @@
           mkdir -p "$out" "$man"
         '';
       };
+      # Drop ubootTools' EFI scripts so they don't pull Rust into the build.
+      ubootTools = super.ubootTools.override { pythonScriptsToInstall = { }; };
     })
   ];
 }


### PR DESCRIPTION
The armv7l kernel build pulls in `ubootTools`, whose `EFI` scripts drag Rust into the build, so drop them since we don't use `EFI`.