### PR TITLE
fix `x86` boot by including kernel modules in the `initrd`

### DIFF
--- a/stage-1.nix
+++ b/stage-1.nix
@@ -5,7 +5,7 @@ let
   modules = pkgs.makeModulesClosure {
     rootModules = config.boot.initrd.availableKernelModules ++ config.boot.initrd.kernelModules;
     allowMissing = true;
-    kernel = config.system.build.kernel;
+    kernel = config.system.build.kernel.modules;
     firmware = config.hardware.firmware;
   };
   plymouth = (pkgs.plymouth.override {
@@ -187,7 +187,10 @@ let
     exec ${shell}
   '';
   initialRamdisk = pkgs.makeInitrd {
-    contents = [ { object = bootStage1; symlink = "/init"; } ];
+    contents = [
+      { object = bootStage1; symlink = "/init"; }
+      { object = modules; symlink = "/lib/modules-store"; }
+    ];
   };
 in
 {


### PR DESCRIPTION
`nixpkgs` now ships kernel modules in a separate output, so the `initrd` ended up with none and the store couldn't be mounted. Point `makeModulesClosure` at that output and add the modules to the `initrd`.

**Before:**
```
<<< NotOS Stage 1 >>>

'/bin/sh' -> '/nix/store/ccr87lhzwkp38w8ka0qp20656lfxly9x-extra-utils/bin/ash'
modprobe: can't change directory to '/lib/modules': No such file or directory
modprobe: can't change directory to '/lib/modules': No such file or directory
modprobe: can't change directory to '/lib/modules': No such file or directory
modprobe: can't change directory to '/lib/modules': No such file or directory
modprobe: can't change directory to '/lib/modules': No such file or directory
modprobe: can't change directory to '/lib/modules': No such file or directory
modprobe: can't change directory to '/lib/modules': No such file or directory
modprobe: can't change directory to '/lib/modules': No such file or directory
modprobe: can't change directory to '/lib/modules': No such file or directory
modprobe: can't change directory to '/lib/modules': No such file or directory
modprobe: can't change directory to '/lib/modules': No such file or directory
mount: mounting /dev/vda on /mnt/nix/.ro-store failed: No such device
```

**After:**
```
<<< NotOS Stage 1 >>>

'/bin/sh' -> '/nix/store/ccr87lhzwkp38w8ka0qp20656lfxly9x-extra-utils/bin/ash'
[    0.452990] Invalid ELF header magic: != ELF
[    0.475149] Invalid ELF header magic: != ELF
[    0.482999] Invalid ELF header magic: != ELF
[    0.502355] Invalid ELF header magic: != ELF
[    0.512703] Invalid ELF header magic: != ELF
[    0.519933] Invalid ELF header magic: != ELF
[    0.524048] Invalid ELF header magic: != ELF
[    0.527666] Invalid ELF header magic: != ELF
[    0.532802] Invalid ELF header magic: != ELF
[    0.537436] Invalid ELF header magic: != ELF
[    0.539473] Invalid ELF header magic: != ELF
[    0.541881] Invalid ELF header magic: != ELF
[    0.552365] Invalid ELF header magic: != ELF
[    0.554485] Invalid ELF header magic: != ELF
[    0.556321] Invalid ELF header magic: != ELF
[    0.573449] Invalid ELF header magic: != ELF
created directory: '/mnt/nix/.overlay-store/work'
created directory: '/mnt/nix/.overlay-store/rw'

<<< NotOS Stage 2 >>>
...
```