### PR TITLE
add `networking.hostName` option

### DIFF
--- a/base.nix
+++ b/base.nix
@@ -48,6 +48,12 @@ with lib;
         The set of NTP servers from which to synchronise.
       '';
     };
+    networking.hostName = mkOption {
+      default = "";
+      type = types.strMatching
+        "^$|^[[:alnum:]]([[:alnum:]_-]{0,61}[[:alnum:]])?$";
+      description = "The name of the machine. Leave empty to not set one.";
+    };
     system.systemBuilderArgs = mkOption {
       type = types.attrsOf types.unspecified;
       internal = true;

--- a/runit.nix
+++ b/runit.nix
@@ -36,6 +36,10 @@ in
           ${pkgs.openssh}/bin/ssh-keygen -t ed25519 -f $ED25519_KEY -N ""
         fi
 
+        ${lib.optionalString (config.networking.hostName != "") ''
+        echo ${config.networking.hostName} > /proc/sys/kernel/hostname
+        ''}
+
         ${lib.optionalString config.not-os.simpleStaticIp ''
         ip addr add 10.0.2.15 dev eth0
         ip link set eth0 up

--- a/zynq_image.nix
+++ b/zynq_image.nix
@@ -13,6 +13,7 @@ in {
   imports = [ ./arm32-cross-fixes.nix ];
   boot.kernelPackages = customKernelPackages;
   nixpkgs.system = "armv7l-linux";
+  networking.hostName = "zynq";
   system.build.zynq_image = let
     cmdline = "root=/dev/mmcblk0 console=ttyPS0,115200n8 systemConfig=${builtins.unsafeDiscardStringContext config.system.build.toplevel}";
     qemuScript = ''


### PR DESCRIPTION
Adds a `networking.hostName` option that sets the machine's hostname at boot.