### PR TITLE
runit: ensure `/etc/ssh` exists before generating host key

### DIFF
--- a/runit.nix
+++ b/runit.nix
@@ -33,6 +33,7 @@ in
         ED25519_KEY="/etc/ssh/ssh_host_ed25519_key"
 
         if [ ! -f $ED25519_KEY ]; then
+          mkdir -p /etc/ssh
           ${pkgs.openssh}/bin/ssh-keygen -t ed25519 -f $ED25519_KEY -N ""
         fi
 


### PR DESCRIPTION
Host key generation in `runit/1` writes to `/etc/ssh` but never creates that directory, so it only works when something else happens to make it first. This ensures that directory exists first.