### PR TITLE
remove `rpi_image_tar` in zynq

### DIFF
--- a/zynq_image.nix
+++ b/zynq_image.nix
@@ -53,11 +53,6 @@ in {
     patchShebangs qemu-script
     ls -ltrh
   '';
-  system.build.rpi_image_tar = pkgs.runCommand "dist.tar" {} ''
-    mkdir -p $out/nix-support
-    tar -cvf $out/dist.tar ${config.system.build.rpi_image}
-    echo "file binary-dist $out/dist.tar" >> $out/nix-support/hydra-build-products
-  '';
   environment.systemPackages = [ pkgs.strace ];
   environment.etc."service/getty/run".source = pkgs.writeShellScript "getty" ''
     agetty ttyPS0 115200


### PR DESCRIPTION
Remove a leftover from the rpi module.