### PR TITLE
zynq_image: make dtb and extra kernel config configurable

### DIFF
--- a/zynq_image.nix
+++ b/zynq_image.nix
@@ -1,62 +1,81 @@
-{ config, pkgs, ... }:
+{ config, pkgs, lib, ... }:
+
+with lib;
 
 let
+  cfg = config.not-os.zynq;
   # dont use overlays for the qemu, it causes a lot of wasted time on recompiles
   x86pkgs = import pkgs.path { system = "x86_64-linux"; };
   customKernel = pkgs.linux.override {
     extraConfig = ''
       OVERLAY_FS y
-    '';
+    '' + cfg.extraKernelConfig;
   };
   customKernelPackages = pkgs.linuxPackagesFor customKernel;
 in {
   imports = [ ./arm32-cross-fixes.nix ];
-  boot.kernelPackages = customKernelPackages;
-  nixpkgs.system = "armv7l-linux";
-  networking.hostName = "zynq";
-  system.build.zynq_image = let
-    cmdline = "root=/dev/mmcblk0 console=ttyPS0,115200n8 systemConfig=${builtins.unsafeDiscardStringContext config.system.build.toplevel}";
-    qemuScript = ''
-      #!/bin/bash -v
-      export PATH=${x86pkgs.qemu}/bin:$PATH
-      set -x
-      base=$(dirname $0)
 
-      cp $base/root.squashfs /tmp/
-      chmod +w /tmp/root.squashfs
-      truncate -s 64m /tmp/root.squashfs
+  options.not-os.zynq = {
+    dtbName = mkOption {
+      type = types.str;
+      default = "zynq-zc702.dtb";
+      description = "Device tree blob (from the kernel's dtbs/) to use for the zynq image.";
+    };
+    extraKernelConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = "Extra kernel config appended to the zynq base config.";
+    };
+  };
 
-      qemu-system-arm \
-        -M xilinx-zynq-a9 \
-        -serial /dev/null \
-        -serial stdio \
-        -display none \
-        -dtb $base/zynq-zc702.dtb \
-        -kernel $base/zImage \
-        -initrd $base/initrd \
-        -drive file=/tmp/root.squashfs,if=sd,format=raw \
-        -append "${cmdline}"
+  config = {
+    boot.kernelPackages = customKernelPackages;
+    nixpkgs.system = "armv7l-linux";
+    networking.hostName = "zynq";
+    system.build.zynq_image = let
+      cmdline = "root=/dev/mmcblk0 console=ttyPS0,115200n8 systemConfig=${builtins.unsafeDiscardStringContext config.system.build.toplevel}";
+      qemuScript = ''
+        #!/bin/bash -v
+        export PATH=${x86pkgs.qemu}/bin:$PATH
+        set -x
+        base=$(dirname $0)
+
+        cp $base/root.squashfs /tmp/
+        chmod +w /tmp/root.squashfs
+        truncate -s 64m /tmp/root.squashfs
+
+        qemu-system-arm \
+          -M xilinx-zynq-a9 \
+          -serial /dev/null \
+          -serial stdio \
+          -display none \
+          -dtb $base/${cfg.dtbName} \
+          -kernel $base/zImage \
+          -initrd $base/initrd \
+          -drive file=/tmp/root.squashfs,if=sd,format=raw \
+          -append "${cmdline}"
+      '';
+    in pkgs.runCommand "zynq_image" {
+      inherit qemuScript;
+      passAsFile = [ "qemuScript" ];
+      preferLocalBuild = true;
+    } ''
+      mkdir $out
+      cd $out
+      cp -s ${config.system.build.squashfs} root.squashfs
+      cp -s ${config.system.build.kernel}/*zImage .
+      cp -s ${config.system.build.initialRamdisk}/initrd initrd
+      cp -s ${config.system.build.kernel}/dtbs/${cfg.dtbName} .
+      ln -sv ${config.system.build.toplevel} toplevel
+      cp $qemuScriptPath qemu-script
+      chmod +x qemu-script
+      patchShebangs qemu-script
+      ls -ltrh
     '';
-  in pkgs.runCommand "zynq_image" {
-    inherit qemuScript;
-    passAsFile = [ "qemuScript" ];
-    preferLocalBuild = true;
-  } ''
-    mkdir $out
-    cd $out
-    cp -s ${config.system.build.squashfs} root.squashfs
-    cp -s ${config.system.build.kernel}/*zImage .
-    cp -s ${config.system.build.initialRamdisk}/initrd initrd
-    cp -s ${config.system.build.kernel}/dtbs/zynq-zc702.dtb .
-    ln -sv ${config.system.build.toplevel} toplevel
-    cp $qemuScriptPath qemu-script
-    chmod +x qemu-script
-    patchShebangs qemu-script
-    ls -ltrh
-  '';
-  environment.systemPackages = [ pkgs.strace ];
-  environment.etc."service/getty/run".source = pkgs.writeShellScript "getty" ''
-    agetty ttyPS0 115200
-  '';
-  environment.etc."pam.d/other".text = "";
+    environment.systemPackages = [ pkgs.strace ];
+    environment.etc."service/getty/run".source = pkgs.writeShellScript "getty" ''
+      agetty ttyPS0 115200
+    '';
+    environment.etc."pam.d/other".text = "";
+  };
 }


### PR DESCRIPTION
Adds two options, `not-os.zynq.dtbName` and `not-os.zynq.extraKernelConfig`, so you can pick the device tree and add kernel config without editing `zynq_image.nix`. Nothing changes by default. Groundwork for an SD-image module later.