### PR TITLE
add opt-in SD-card boot support

### DIFF
--- a/base.nix
+++ b/base.nix
@@ -31,6 +31,11 @@ with lib;
       description = "enable rngd";
       default = false;
     };
+    not-os.sd = mkOption {
+      type = types.bool;
+      default = false;
+      description = "boot from an SD card (vfat /boot + ext4 root) instead of a squashfs store";
+    };
     not-os.simpleStaticIp = mkOption {
       type = types.bool;
       default = false;

--- a/runit.nix
+++ b/runit.nix
@@ -93,7 +93,11 @@ in
       '';
       "service/nix/run".source = pkgs.writeScript "nix" ''
         #!${pkgs.runtimeShell}
-        nix-store --load-db < /nix/store/nix-path-registration
+        # Load the shipped store paths into the db, once: only if the db isn't
+        # built yet, and only if the registration file is present (absent on SD).
+        if [ ! -e /nix/var/nix/db/db.sqlite ] && [ -e /nix/store/nix-path-registration ]; then
+          nix-store --load-db < /nix/store/nix-path-registration
+        fi
         nix-daemon
       '';
     }

--- a/stage-1.nix
+++ b/stage-1.nix
@@ -163,7 +163,26 @@ let
     mkdir -p /mnt/nix/store/
 
 
-    ${if config.not-os.nix then ''
+    ${if config.not-os.sd && config.not-os.nix then ''
+    # SD boot: a vfat /boot partition plus a full ext4 root.
+    # Read-only by default (ext4 lower + tmpfs overlay),
+    # writeable when the file /boot/fs_mode_rw exists.
+    mkdir -p /boot
+    mount -t vfat -o ro /dev/mmcblk0p1 /boot
+    if [ -e /boot/fs_mode_rw ]; then
+      echo "found /boot/fs_mode_rw, mounting root read-write"
+      mount $root /mnt
+    else
+      mkdir -p /mnt.ro /mnt.overlay
+      mount -o ro $root /mnt.ro
+      mount -t tmpfs -o size=256M tmpfs /mnt.overlay
+      mkdir -p /mnt.overlay/upper /mnt.overlay/work
+      modprobe overlay
+      mount -t overlay overlay -o lowerdir=/mnt.ro,upperdir=/mnt.overlay/upper,workdir=/mnt.overlay/work /mnt
+    fi
+    mkdir -p /mnt/boot
+    mount --move /boot /mnt/boot
+    '' else if config.not-os.nix then ''
     # make the store writeable
     mkdir -p /mnt/nix/.ro-store /mnt/nix/.overlay-store /mnt/nix/store
     mount $root /mnt/nix/.ro-store -t squashfs


### PR DESCRIPTION
Add a `not-os.sd` option (default false). When set, stage-1 mounts a `vfat` `/boot` partition and a full `ext4` `root` instead of the `squashfs` store: read-only via a `tmpfs` overlay by default, or read-write when a file `/boot/fs_mode_rw` exists.

Also guard the per-boot `nix-store --load-db`, which only applies to a `squashfs` store. Everything is gated behind `not-os.sd`, so the default boot path is unchanged. Tested booting on Zynq (zc706) hardware.