### PR TITLE
add `not-os.extraInit` option

### DIFF
--- a/base.nix
+++ b/base.nix
@@ -41,6 +41,11 @@ with lib;
       default = false;
       description = "set a static ip of 10.0.2.15";
     };
+    not-os.extraInit = mkOption {
+      type = types.lines;
+      default = "";
+      description = "extra shell commands to run at the end of runit's first script";
+    };
     networking.timeServers = mkOption {
       default = [
         "0.nixos.pool.ntp.org"

--- a/runit.nix
+++ b/runit.nix
@@ -60,6 +60,8 @@ in
         touch /etc/runit/stopit
         chmod 0 /etc/runit/stopit
         ${if true then "" else "${pkgs.dhcpcd}/sbin/dhcpcd"}
+
+        ${config.not-os.extraInit}
       '';
       "runit/2".source = pkgs.writeScript "2" ''
         #!${pkgs.runtimeShell}


### PR DESCRIPTION
Let downstream configs extend runit's boot script. Useful for any custom boot time setup without patching `not-os`.